### PR TITLE
docs: reposition harness-creator as a reusable agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 
 ## What It Is
 
-`harness-creator` is a Codex skill for analyzing, designing, and implementing production-ready agent harnesses.
+`harness-creator` is an open `SKILL.md`-based agent skill for analyzing, designing, and implementing production-ready agent harnesses.
+
+It is written to work well in Codex, OpenClaw, Claude Code, Hermes Agent, and other coding agents that can read skill-style Markdown instructions. The repo is not limited to Codex-only workflows.
 
 It helps you turn a fuzzy request like:
 
@@ -20,6 +22,16 @@ It helps you turn a fuzzy request like:
 - "Design an MCP-enabled agent runtime"
 
 into a concrete, layered runtime design with clear module boundaries, implementation order, and safety rules.
+
+## Compatibility
+
+This repository follows the portable `SKILL.md` pattern used across the broader agent-skills ecosystem.
+
+- Works well in: Codex, OpenClaw, Claude Code, Hermes Agent
+- Usually portable to: other agents that ingest Markdown skill instructions
+- Best fit: coding-agent runtimes, CLI agents, MCP-enabled assistants, orchestrators, and multi-step tool-using systems
+
+If your agent supports custom skills, custom instructions, or task-scoped Markdown playbooks, this repo can usually be used directly or with light adaptation.
 
 ## Why People Install It
 
@@ -41,6 +53,16 @@ Most agent designs fail in one of two ways:
 - A concrete implementation order from minimal loop to advanced orchestration.
 - A required output contract so analysis does not stop at "I inspected these files."
 - Strong guidance for permissions, planning, subagents, memory, compaction, integrations, and verification.
+
+## What Makes This Repo Useful
+
+Good skill homepages usually answer three questions fast: what problem it solves, what changes after installing it, and whether it fits your stack.
+
+This repo is optimized around those three:
+
+- it targets a specific high-value problem: agent harness architecture
+- it shows behavioral difference before vs after the skill
+- it is packaged as a reusable instruction asset, not a Codex-only experiment
 
 ## Skill Highlights
 
@@ -97,7 +119,18 @@ That difference saves time in real engineering work. Instead of spending another
 
 ## Quick Start
 
-Clone or copy this repository into your Codex skills directory:
+Clone or copy this repository into your agent skills directory.
+
+### Common skill locations
+
+```text
+Codex:       ~/.codex/skills/harness-creator
+Claude Code: ~/.claude/skills/harness-creator
+OpenClaw:    ~/.openclaw/skills/harness-creator
+Hermes:      ~/.hermes/skills/harness-creator
+```
+
+If your tool uses a project-local skills folder instead of a global one, copy this repo into that location and keep the `SKILL.md` at the skill root.
 
 ### Windows
 
@@ -113,13 +146,29 @@ git clone https://github.com/Arthurescc/harness-creator \
   "${HOME}/.codex/skills/harness-creator"
 ```
 
+Then copy or symlink the same folder into any other agent's skills directory if you want to share one canonical version across tools.
+
 If you use `CODEX_HOME`, install it under:
 
 ```text
 $CODEX_HOME/skills/harness-creator
 ```
 
-Restart Codex after installation so the skill list refreshes.
+Restart or refresh your agent after installation so the skill list reloads.
+
+### Windows example for Claude Code
+
+```powershell
+git clone https://github.com/Arthurescc/harness-creator `
+  "$env:USERPROFILE\\.claude\\skills\\harness-creator"
+```
+
+### macOS / Linux example for Claude Code
+
+```bash
+git clone https://github.com/Arthurescc/harness-creator \
+  "${HOME}/.claude/skills/harness-creator"
+```
 
 ## Example Prompts
 
@@ -127,6 +176,14 @@ Restart Codex after installation so the skill list refreshes.
 - `Use $harness-creator to refactor our current agent runtime into a layered harness.`
 - `Use $harness-creator to propose how to add planning, subagents, and MCP support without breaking safety.`
 - `Use $harness-creator to compare our current design against stronger runtime patterns and identify the gaps.`
+
+## What This Skill Clarifies Better Than Generic Agent Advice
+
+- where the loop ends and orchestration begins
+- when to add planning, permissions, persistence, and compaction
+- what should live in prompts vs tools vs runtime code
+- how to sequence implementation so reliability arrives before autonomy
+- how to separate facts, recommendations, and unknowns in architecture work
 
 ## Repository Layout
 
@@ -143,7 +200,7 @@ assets/
 
 ## Development
 
-This project is independently designed and developed for practical Codex skill workflows.
+This project is independently designed and developed for practical agent-skill workflows across multiple coding agents.
 
 It is focused on improving output quality, implementation readiness, and safety discipline for agent-harness design work.
 
@@ -163,6 +220,26 @@ See [README.zh-CN.md](README.zh-CN.md).
 ## More Skills
 
 Browse the collection page: [codex-skills-hub](https://github.com/Arthurescc/codex-skills-hub)
+
+## FAQ
+
+### Is this only for Codex?
+
+No. It is authored in the open `SKILL.md` format and is meant to be portable across Codex, OpenClaw, Claude Code, Hermes Agent, and similar tools.
+
+### Do I need to change the skill for each agent?
+
+Usually no. In many tools the same `SKILL.md` works directly. Some ecosystems may prefer a different install path or wrapper format, but the core instructions remain reusable.
+
+### Who should use this?
+
+Use it when you are building or refactoring:
+
+- coding agents
+- CLI assistants
+- tool-calling runtimes
+- multi-step agent backends
+- MCP-aware orchestration systems
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,9 @@
   <img src="assets/icon-large.svg" alt="Harness Creator icon" width="140" />
 </p>
 
-`harness-creator` 是一个面向 Codex 的技能，专门用于分析、设计和实现更安全、更可落地的 agent harness。
+`harness-creator` 是一个基于开放 `SKILL.md` 约定的 agent skill，专门用于分析、设计和实现更安全、更可落地的 agent harness。
+
+它并不只服务于 Codex，也可以用于 OpenClaw、Claude Code、Hermes Agent，以及其他能够读取 skill 式 Markdown 指令的主流智能体工具。
 
 它不是泛泛而谈的提示模板，而是把问题收束到真正能落地的几个层次：
 
@@ -17,6 +19,14 @@
 - compaction
 - integrations
 - verification
+
+## 兼容性
+
+这个仓库遵循的是更通用的 `SKILL.md` 技能写法，而不是某一个产品私有的格式。
+
+- 直接适配较好的工具：Codex、OpenClaw、Claude Code、Hermes Agent
+- 一般也容易迁移到：支持自定义 skill / instructions / playbook 的其他智能体工具
+- 最适合的任务：coding agent runtime、CLI agent、MCP 集成助手、长流程 tool-using agent
 
 ## 它的价值
 
@@ -56,6 +66,16 @@
 - 安全和验证不再是附带说明，而是核心组成
 - 会更明确地区分“已经确认的内容”和“建议这样设计的内容”
 
+## 为什么这个首页要这样写
+
+很多优秀的开源 skill 首页，都会很快回答这几个问题：
+
+- 这是干什么的
+- 用了之后会具体改善什么
+- 我现在用的智能体能不能直接装
+
+这个 README 也按这个思路组织，避免读者看到一半还不知道它是不是只能给 Codex 用。
+
 ## 案例
 
 ### 场景：设计一个生产可用的 CLI coding agent
@@ -71,6 +91,19 @@
 
 ## 安装方式
 
+把仓库克隆到你的技能目录即可。
+
+### 常见技能目录
+
+```text
+Codex:       ~/.codex/skills/harness-creator
+Claude Code: ~/.claude/skills/harness-creator
+OpenClaw:    ~/.openclaw/skills/harness-creator
+Hermes:      ~/.hermes/skills/harness-creator
+```
+
+如果你的工具使用项目内 skills 目录，也可以直接把本仓库放进去，只要保持 `SKILL.md` 在 skill 根目录即可。
+
 ### Windows
 
 ```powershell
@@ -85,13 +118,22 @@ git clone https://github.com/Arthurescc/harness-creator \
   "${HOME}/.codex/skills/harness-creator"
 ```
 
+如果你希望多个智能体共用同一份 skill，可以把同一个目录再复制或软链接到其他 agent 的 skills 目录。
+
 如果你使用 `CODEX_HOME`，请安装到：
 
 ```text
 $CODEX_HOME/skills/harness-creator
 ```
 
-安装后重启 Codex，让技能列表刷新。
+安装后重启或刷新对应智能体，让技能列表刷新。
+
+### Claude Code 安装示例
+
+```bash
+git clone https://github.com/Arthurescc/harness-creator \
+  "${HOME}/.claude/skills/harness-creator"
+```
 
 ## 使用示例
 
@@ -99,6 +141,14 @@ $CODEX_HOME/skills/harness-creator
 - `Use $harness-creator to refactor our current agent runtime into a layered harness.`
 - `Use $harness-creator to propose how to add planning, subagents, and MCP support without breaking safety.`
 - `Use $harness-creator to compare our current design against stronger runtime patterns and identify the gaps.`
+
+## 这个 skill 比泛化 agent 建议更擅长讲清楚什么
+
+- loop 和 orchestration 的边界
+- planning、permissions、persistence、compaction 应该在什么时候引入
+- 什么应该放在 prompt，什么应该沉到 tools 或 runtime
+- 实施顺序怎么排，才能先得到可靠性，再得到自治能力
+- 架构分析里哪些是事实，哪些是推荐设计，哪些还属于未知
 
 ## 仓库内容
 
@@ -111,13 +161,33 @@ assets/
 
 ## 开发说明
 
-本项目为自研开发，面向实际 Codex 技能工作流使用。
+本项目为自研开发，面向多种 coding agent 的实际技能工作流使用。
 
 重点在于提升 agent harness 设计任务中的输出质量、可实施性和安全性。
 
 ## 更多技能
 
 总导航页见：[codex-skills-hub](https://github.com/Arthurescc/codex-skills-hub)
+
+## FAQ
+
+### 这是只给 Codex 用的吗？
+
+不是。它采用开放的 `SKILL.md` 结构，目标就是尽量在 Codex、OpenClaw、Claude Code、Hermes Agent 这类工具之间复用。
+
+### 不同智能体要分别改写一份吗？
+
+多数情况下不用。通常只需要调整安装位置；核心技能内容本身是可复用的。
+
+### 适合谁用？
+
+适合以下场景：
+
+- 做 coding agent
+- 做 CLI assistant
+- 做 tool-calling runtime
+- 做多步骤 agent backend
+- 做 MCP-aware orchestration system
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-creator
-description: Design and implement safe, layered agent harnesses and orchestration workflows. Use when the user wants a coding agent, CLI agent, tool-calling assistant, multi-agent runtime, plan/task system, subagent framework, MCP-integrated harness, or Claude Code/Codex-style agent workflow built or refactored.
+description: Design and implement safe, layered agent harnesses and orchestration workflows. Portable across Codex, OpenClaw, Claude Code, Hermes Agent, and similar SKILL.md-compatible coding agents. Use when the user wants a coding agent, CLI agent, tool-calling assistant, multi-agent runtime, plan/task system, subagent framework, MCP-integrated harness, or Claude Code/Codex-style agent workflow built or refactored.
 ---
 
 # Harness Creator


### PR DESCRIPTION
## Summary
- reposition the repo from Codex-only wording to cross-agent skill language
- add compatibility, install path, and FAQ guidance for Codex, OpenClaw, Claude Code, and Hermes Agent
- update the skill description to reflect portable SKILL.md usage

## Validation
- git diff --check